### PR TITLE
perf: skip aliases

### DIFF
--- a/bin/nodenv-nvmrc
+++ b/bin/nodenv-nvmrc
@@ -58,7 +58,7 @@ version_from_nvmrc() {
       if [[ $v =~ ^[0-9.]+$ ]] ; then
         installed_versions+=( "$v" )
       fi
-    done < <(nodenv versions --bare)
+    done < <(nodenv versions --bare --skip-aliases)
 
     version=$("$SEMVER" -r "$version_expression" "${installed_versions[@]}" \
       | tail -n 1)


### PR DESCRIPTION
When this plugin is used in combination with nodenv-aliases, some aliases are created that match the regexp `^[0-9.]+$` and are therefore passed on to sh-semver which seems particularily slow at dealing with them.

Since aliases are redundant anyway, we can simply ask nodenv to skip them when listing installed node versions.

Fixes #8

## Note

Tests fail on my machine for master branch, so I'm not able to tell if this change introduces a regression / not able to add a test case to cover this change.

I can confirm though that `node -v` is now snappy on my machine with that change.